### PR TITLE
Refactor/meet controller

### DIFF
--- a/ThesisBackend/Program.cs
+++ b/ThesisBackend/Program.cs
@@ -20,6 +20,9 @@ using ThesisBackend.Application.UserService.Interfaces;
 using ThesisBackend.Services.CarService.Interfaces;
 using ThesisBackend.Services.CarService.Services;
 using ThesisBackend.Services.CarService.Validators;
+using ThesisBackend.Services.MeetService.Interfaces;
+using ThesisBackend.Services.MeetService.Services;
+using ThesisBackend.Services.MeetService.Validators;
 using ThesisBackend.Services.UserService.Services;
 using ThesisBackend.Services.UserService.Validators;
 
@@ -86,6 +89,7 @@ builder.Services.AddControllers()
         config.RegisterValidatorsFromAssemblyContaining<RegistrationRequestValidator>();
         config.RegisterValidatorsFromAssemblyContaining<UserRequestValidator>();
         config.RegisterValidatorsFromAssemblyContaining<CarRequestValidator>();
+        config.RegisterValidatorsFromAssemblyContaining<MeetRequestValidator>();
         config.AutomaticValidationEnabled = false;
     });
 
@@ -102,6 +106,7 @@ builder.Services.AddScoped<ITokenGenerator, TokenGenerator>();
 builder.Services.AddScoped<IPasswordHasher, PasswordHasher>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<ICarService, CarService>();
+builder.Services.AddScoped<IMeetService, MeetService>();
 
 builder.Services.AddCors(options =>
 {

--- a/ThesisBackend/ThesisBackend.Api.Tests/MeetController/MeetControllerTests.cs
+++ b/ThesisBackend/ThesisBackend.Api.Tests/MeetController/MeetControllerTests.cs
@@ -1,0 +1,138 @@
+﻿using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using ThesisBackend.Data;
+using ThesisBackend.Domain.Messages;
+using ThesisBackend.Domain.Models;
+using Xunit;
+using Xunit.Abstractions;
+using FluentAssertions;
+
+namespace ThesisBackend.Api.Tests.MeetController;
+
+public class MeetControllerTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ITestOutputHelper _output;
+
+    public MeetControllerTests(WebApplicationFactory<Program> factory, ITestOutputHelper output)
+    {
+        _output = output;
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Testing");
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll(typeof(DbContextOptions<dbContext>));
+                var dbName = $"InMemoryDbForTesting_{Guid.NewGuid()}";
+                services.AddDbContext<dbContext>(options =>
+                {
+                    options.UseInMemoryDatabase(dbName);
+                });
+            });
+        });
+
+        _client = _factory.CreateClient();
+    }
+
+    private async Task<Domain.Models.User> SeedUserAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<dbContext>();
+        await context.Database.EnsureDeletedAsync();
+        await context.Database.EnsureCreatedAsync();
+
+        var user = new Domain.Models.User { Id = 1, Nickname = "TestUser", Email = "test@example.com", PasswordHash = "hash" };
+        context.Users.Add(user);
+        await context.SaveChangesAsync();
+        return user;
+    }
+
+    [Fact]
+    public async Task AddMeet_ShouldReturnOk_WhenRequestIsValid()
+    {
+        // Arrange
+        var user = await SeedUserAsync();
+        var meetRequest = new MeetRequest
+        {
+            Name = "API Test Meet",
+            Description = "Description",
+            Location = "API Test Location",
+            Coordinates = "47.4979,19.0402",
+            Date = DateTime.UtcNow.AddHours(25),
+            Tags = new List<MeetTags> { MeetTags.Offroad },
+            Private = false
+        };
+
+        // Act
+        var response = await _client.PostAsJsonAsync($"/api/v1/Meet/addMeet/{user.Id}", meetRequest);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var meetResponse = await response.Content.ReadFromJsonAsync<MeetResponse>();
+        meetResponse.Should().NotBeNull();
+        meetResponse?.Name.Should().Be("API Test Meet");
+    }
+
+    [Fact]
+    public async Task GetMeet_ShouldReturnMeet_WhenExists()
+    {
+        // Arrange
+        var user = await SeedUserAsync();
+        var meetRequest = new MeetRequest
+        {
+            Name = "Gettable Meet",
+            Location = "Location",
+            Description = "Description",
+            Coordinates = "47.4979,19.0402",
+            Date = DateTime.UtcNow.AddHours(25), // JAVÍTÁS
+            Tags = new List<MeetTags> { MeetTags.Show }
+        };
+        var addResponse = await _client.PostAsJsonAsync($"/api/v1/Meet/addMeet/{user.Id}", meetRequest);
+        var addedMeet = await addResponse.Content.ReadFromJsonAsync<MeetResponse>();
+        Assert.NotNull(addedMeet);
+
+        // Act
+        var getResponse = await _client.GetAsync($"/api/v1/Meet/getMeet/{addedMeet.Id}");
+
+        // Assert
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var fetchedMeet = await getResponse.Content.ReadFromJsonAsync<MeetResponse>();
+        fetchedMeet.Should().NotBeNull();
+        fetchedMeet?.Name.Should().Be("Gettable Meet");
+    }
+    
+    [Fact]
+    public async Task DeleteMeet_ShouldReturnOk_WhenMeetExists()
+    {
+        // Arrange
+        var user = await SeedUserAsync();
+        var meetRequest = new MeetRequest
+        {
+            Name = "Deletable Meet",
+            Description = "Description",
+            Location = "Location",
+            Coordinates = "47.4979,19.0402",
+            Date = DateTime.UtcNow.AddHours(25), // JAVÍTÁS
+            Tags = new List<MeetTags> { MeetTags.Show }
+        };
+        var addResponse = await _client.PostAsJsonAsync($"/api/v1/Meet/addMeet/{user.Id}", meetRequest);
+        var addedMeet = await addResponse.Content.ReadFromJsonAsync<MeetResponse>();
+        Assert.NotNull(addedMeet);
+
+        // Act
+        var deleteResponse = await _client.DeleteAsync($"/api/v1/Meet/deleteMeet/{addedMeet.Id}");
+
+        // Assert
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Verify it's actually deleted
+        var getResponse = await _client.GetAsync($"/api/v1/Meet/getMeet/{addedMeet.Id}");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/ThesisBackend/ThesisBackend.Api.Tests/MeetController/MeetControllerTests.cs
+++ b/ThesisBackend/ThesisBackend.Api.Tests/MeetController/MeetControllerTests.cs
@@ -90,7 +90,7 @@ public class MeetControllerTests : IClassFixture<WebApplicationFactory<Program>>
             Location = "Location",
             Description = "Description",
             Coordinates = "47.4979,19.0402",
-            Date = DateTime.UtcNow.AddHours(25), // JAVÍTÁS
+            Date = DateTime.UtcNow.AddHours(25),
             Tags = new List<MeetTags> { MeetTags.Show }
         };
         var addResponse = await _client.PostAsJsonAsync($"/api/v1/Meet/addMeet/{user.Id}", meetRequest);
@@ -118,7 +118,7 @@ public class MeetControllerTests : IClassFixture<WebApplicationFactory<Program>>
             Description = "Description",
             Location = "Location",
             Coordinates = "47.4979,19.0402",
-            Date = DateTime.UtcNow.AddHours(25), // JAVÍTÁS
+            Date = DateTime.UtcNow.AddHours(25),
             Tags = new List<MeetTags> { MeetTags.Show }
         };
         var addResponse = await _client.PostAsJsonAsync($"/api/v1/Meet/addMeet/{user.Id}", meetRequest);

--- a/ThesisBackend/ThesisBackend.Domain/Messages/MeetResponse.cs
+++ b/ThesisBackend/ThesisBackend.Domain/Messages/MeetResponse.cs
@@ -16,6 +16,8 @@ public class MeetResponse
 	public List<MeetTags> Tags { get; set; } = new List<MeetTags>();
 	public List<UserResponse> Users { get; set; } = new List<UserResponse>();
 	
+	public MeetResponse(){}
+	
 	public MeetResponse(Meet meet)
 	{
 		Id = meet.Id;

--- a/ThesisBackend/ThesisBackend.Domain/Messages/SmallEventResponse.cs
+++ b/ThesisBackend/ThesisBackend.Domain/Messages/SmallEventResponse.cs
@@ -26,4 +26,8 @@ public class SmallEventResponse
 		Private = race.Private;
 		IsMeet = false;
 	}
+
+	public SmallEventResponse()
+	{
+	}
 }

--- a/ThesisBackend/ThesisBackend.Services.Tests/Meet/Services/MeetServiceTest.cs
+++ b/ThesisBackend/ThesisBackend.Services.Tests/Meet/Services/MeetServiceTest.cs
@@ -1,0 +1,145 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ThesisBackend.Data;
+using ThesisBackend.Domain.Messages;
+using ThesisBackend.Domain.Models;
+using ThesisBackend.Services.MeetService;
+using Xunit;
+
+namespace ThesisBackend.Services.Tests.Meet.Services;
+
+public class MeetServiceTest
+{
+    private readonly MeetService.Services.MeetService _meetService;
+    private readonly Mock<ILogger<MeetService.Services.MeetService>> _mockLogger;
+    private readonly dbContext _dbContext;
+
+    public MeetServiceTest()
+    {
+        var options = new DbContextOptionsBuilder<dbContext>()
+            .UseInMemoryDatabase(databaseName: System.Guid.NewGuid().ToString())
+            .Options;
+        _dbContext = new dbContext(options);
+        _mockLogger = new Mock<ILogger<MeetService.Services.MeetService>>();
+        _meetService = new MeetService.Services.MeetService(_dbContext, _mockLogger.Object);
+    }
+
+    private async Task<Domain.Models.User> SeedUserAsync()
+    {
+        var user = new Domain.Models.User { Id = 1, Nickname = "TestUser", Email = "test@example.com", PasswordHash = "hash" };
+        _dbContext.Users.Add(user);
+        await _dbContext.SaveChangesAsync();
+        return user;
+    }
+
+    [Fact]
+    public async Task AddMeetAsync_ShouldAddMeet_WhenUserExists()
+    {
+        // Arrange
+        var user = await SeedUserAsync();
+        var meetRequest = new MeetRequest
+        {
+            Name = "Test Meet",
+            Location = "Test Location",
+            Description = "Test Description",
+            Coordinates = "47.4979,19.0402",
+            Date = DateTime.UtcNow.AddDays(1),
+            Tags = new List<MeetTags> { MeetTags.Drift }
+        };
+
+        // Act
+        var result = await _meetService.AddMeetAsync(meetRequest, user.Id);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(result.MeetResponse);
+        Assert.Equal("Test Meet", result.MeetResponse.Name);
+        var meetInDb = await _dbContext.Meets.FirstOrDefaultAsync();
+        Assert.NotNull(meetInDb);
+        Assert.Equal("Test Meet", meetInDb.Name);
+    }
+
+    [Fact]
+    public async Task GetMeetAsync_ShouldReturnMeet_WhenMeetExists()
+    {
+        // Arrange
+        var user = await SeedUserAsync();
+        var meet = new Domain.Models.Meet(new MeetRequest
+        {
+            Name = "Existing Meet",
+            Location = "Location",
+            Description = "Test Description",
+            Coordinates = "47.4979,19.0402",
+            Date = DateTime.UtcNow.AddDays(1),
+            Tags = new List<MeetTags> { MeetTags.Show }
+        }, user, null);
+        _dbContext.Meets.Add(meet);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _meetService.GetMeetAsync(meet.Id);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(result.MeetResponse);
+        Assert.Equal(meet.Id, result.MeetResponse.Id);
+    }
+    
+    [Fact]
+    public async Task DeleteMeetAsync_ShouldDeleteMeet_WhenMeetExists()
+    {
+        // Arrange
+        var user = await SeedUserAsync();
+        var meet = new Domain.Models.Meet(new MeetRequest
+        {
+            Name = "To Be Deleted",
+            Location = "Location",
+            Description = "Test Description",
+            Coordinates = "47.4979,19.0402",
+            Date = DateTime.UtcNow.AddDays(1),
+            Tags = new List<MeetTags> { MeetTags.Show }
+        }, user, null);
+        _dbContext.Meets.Add(meet);
+        await _dbContext.SaveChangesAsync();
+        var meetIdToDelete = meet.Id;
+
+        // Act
+        var result = await _meetService.DeleteMeetAsync(meetIdToDelete);
+
+        // Assert
+        Assert.True(result.Success);
+        var meetInDb = await _dbContext.Meets.FindAsync(meetIdToDelete);
+        Assert.Null(meetInDb);
+    }
+
+    [Fact]
+    public async Task JoinMeetAsync_ShouldAddUserToMeet_WhenBothExist()
+    {
+        // Arrange
+        var user = await SeedUserAsync();
+        var meet = new Domain.Models.Meet(new MeetRequest
+        {
+            Name = "Joinable Meet",
+            Location = "Location",
+            Description = "Test Description",
+            Coordinates = "47.4979,19.0402",
+            Date = DateTime.UtcNow.AddDays(1),
+            Tags = new List<MeetTags> { MeetTags.Show }
+        }, user, null);
+        _dbContext.Meets.Add(meet);
+
+        var anotherUser = new Domain.Models.User { Id = 2, Nickname = "AnotherUser", Email = "another@example.com", PasswordHash = "hash" };
+        _dbContext.Users.Add(anotherUser);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _meetService.JoinMeetAsync(meet.Id, anotherUser.Id);
+
+        // Assert
+        Assert.True(result.Success);
+        var meetInDb = await _dbContext.Meets.Include(m => m.Users).FirstOrDefaultAsync(m => m.Id == meet.Id);
+        Assert.NotNull(meetInDb);
+        Assert.Contains(meetInDb.Users, u => u.Id == anotherUser.Id);
+    }
+}

--- a/ThesisBackend/ThesisBackend.Services/MeetService/Interfaces/IMeetService.cs
+++ b/ThesisBackend/ThesisBackend.Services/MeetService/Interfaces/IMeetService.cs
@@ -1,0 +1,15 @@
+﻿using ThesisBackend.Domain.Messages;
+using ThesisBackend.Services.MeetService.Models;
+
+namespace ThesisBackend.Services.MeetService.Interfaces;
+
+public interface IMeetService
+{
+    Task<MeetOperationResult> AddMeetAsync(MeetRequest meetRequest, int userId);
+    Task<MeetOperationResult> UpdateMeetAsync(MeetRequest meetRequest, int meetId);
+    Task<MeetOperationResult> GetMeetAsync(int meetId);
+    Task<MeetOperationResult> DeleteMeetAsync(int meetId);
+    Task<MeetOperationResult> JoinMeetAsync(int meetId, int userId);
+    Task<AllMeetsOperationResult> GetAllMeetsAsync();
+    Task<AllMeetsOperationResult> GetFilteredMeetsAsync(LocationQuery query);
+}

--- a/ThesisBackend/ThesisBackend.Services/MeetService/Models/MeetOperationResult.cs
+++ b/ThesisBackend/ThesisBackend.Services/MeetService/Models/MeetOperationResult.cs
@@ -1,0 +1,17 @@
+﻿using ThesisBackend.Domain.Messages;
+
+namespace ThesisBackend.Services.MeetService.Models;
+
+public class MeetOperationResult
+{
+    public bool Success { get; set; }
+    public string? ErrorMessage { get; set; }
+    public MeetResponse? MeetResponse { get; set; }
+}
+
+public class AllMeetsOperationResult
+{
+    public bool Success { get; set; }
+    public string? ErrorMessage { get; set; }
+    public List<SmallEventResponse>? Meets { get; set; }
+}

--- a/ThesisBackend/ThesisBackend.Services/MeetService/Services/MeetService.cs
+++ b/ThesisBackend/ThesisBackend.Services/MeetService/Services/MeetService.cs
@@ -57,7 +57,7 @@ public class MeetService : IMeetService
         var crew = meetRequest.CrewId.HasValue ? await _context.Crews.FindAsync(meetRequest.CrewId.Value) : null;
         if (meetRequest.CrewId.HasValue && crew == null)
         {
-             _logger.LogWarning("Crew not found with ID: {CrewId}", meetRequest.CrewId);
+            _logger.LogWarning("Crew not found with ID: {CrewId}", meetRequest.CrewId);
             return new MeetOperationResult { Success = false, ErrorMessage = "Crew not found" };
         }
 

--- a/ThesisBackend/ThesisBackend.Services/MeetService/Services/MeetService.cs
+++ b/ThesisBackend/ThesisBackend.Services/MeetService/Services/MeetService.cs
@@ -141,7 +141,7 @@ public class MeetService : IMeetService
 
         var queryable = _context.Meets.AsQueryable();
 
-        queryable = queryable.Where(m => m.Date >= DateTime.Today);
+        queryable = queryable.Where(m => m.Date >= DateTime.UtcNow.Date);
         if (query.Tags.Any())
         {
             var meetTags = query.Tags.Select(t => Enum.Parse<MeetTags>(t, true)).ToList();

--- a/ThesisBackend/ThesisBackend.Services/MeetService/Services/MeetService.cs
+++ b/ThesisBackend/ThesisBackend.Services/MeetService/Services/MeetService.cs
@@ -1,0 +1,172 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ThesisBackend.Data;
+using ThesisBackend.Domain.Messages;
+using ThesisBackend.Domain.Models;
+using ThesisBackend.Services.MeetService.Interfaces;
+using ThesisBackend.Services.MeetService.Models;
+
+namespace ThesisBackend.Services.MeetService.Services;
+
+public class MeetService : IMeetService
+{
+    private readonly dbContext _context;
+    private readonly ILogger<MeetService> _logger;
+
+    public MeetService(dbContext context, ILogger<MeetService> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task<MeetOperationResult> AddMeetAsync(MeetRequest meetRequest, int userId)
+    {
+        _logger.LogInformation("Attempting to add a new meet for user {UserId}", userId);
+        var user = await _context.Users.FindAsync(userId);
+        if (user == null)
+        {
+            _logger.LogWarning("User not found with ID: {UserId}", userId);
+            return new MeetOperationResult { Success = false, ErrorMessage = "User not found" };
+        }
+
+        var crew = meetRequest.CrewId.HasValue ? await _context.Crews.FindAsync(meetRequest.CrewId.Value) : null;
+        if (meetRequest.CrewId.HasValue && crew == null)
+        {
+            _logger.LogWarning("Crew not found with ID: {CrewId}", meetRequest.CrewId);
+            return new MeetOperationResult { Success = false, ErrorMessage = "Crew not found" };
+        }
+
+        var newMeet = new Meet(meetRequest, user, crew);
+        _context.Meets.Add(newMeet);
+        await _context.SaveChangesAsync();
+
+        _logger.LogInformation("Meet {MeetName} created successfully by user {UserId}", newMeet.Name, userId);
+        return new MeetOperationResult { Success = true, MeetResponse = new MeetResponse(newMeet) };
+    }
+
+    public async Task<MeetOperationResult> UpdateMeetAsync(MeetRequest meetRequest, int meetId)
+    {
+        _logger.LogInformation("Attempting to update meet with ID: {MeetId}", meetId);
+        var meet = await _context.Meets.FindAsync(meetId);
+        if (meet == null)
+        {
+            _logger.LogWarning("Meet not found with ID: {MeetId}", meetId);
+            return new MeetOperationResult { Success = false, ErrorMessage = "Meet not found" };
+        }
+
+        var crew = meetRequest.CrewId.HasValue ? await _context.Crews.FindAsync(meetRequest.CrewId.Value) : null;
+        if (meetRequest.CrewId.HasValue && crew == null)
+        {
+             _logger.LogWarning("Crew not found with ID: {CrewId}", meetRequest.CrewId);
+            return new MeetOperationResult { Success = false, ErrorMessage = "Crew not found" };
+        }
+
+        meet.UpdateMeet(meetRequest, crew);
+        await _context.SaveChangesAsync();
+        _logger.LogInformation("Meet with ID {MeetId} updated successfully", meetId);
+
+        return new MeetOperationResult { Success = true, MeetResponse = new MeetResponse(meet) };
+    }
+
+    public async Task<MeetOperationResult> GetMeetAsync(int meetId)
+    {
+        _logger.LogInformation("Attempting to retrieve meet with ID: {MeetId}", meetId);
+        var meet = await _context.Meets.Include(m => m.Users).FirstOrDefaultAsync(m => m.Id == meetId);
+        if (meet == null)
+        {
+            _logger.LogWarning("Meet not found with ID: {MeetId}", meetId);
+            return new MeetOperationResult { Success = false, ErrorMessage = "Meet not found" };
+        }
+
+        return new MeetOperationResult { Success = true, MeetResponse = new MeetResponse(meet, meet.Users.ToList()) };
+    }
+
+    public async Task<MeetOperationResult> DeleteMeetAsync(int meetId)
+    {
+        _logger.LogInformation("Attempting to delete meet with ID: {MeetId}", meetId);
+        var meet = await _context.Meets.FindAsync(meetId);
+        if (meet == null)
+        {
+            _logger.LogWarning("Meet not found with ID: {MeetId}", meetId);
+            return new MeetOperationResult { Success = false, ErrorMessage = "Meet not found" };
+        }
+
+        _context.Meets.Remove(meet);
+        await _context.SaveChangesAsync();
+        _logger.LogInformation("Meet with ID {MeetId} deleted successfully", meetId);
+
+        return new MeetOperationResult { Success = true };
+    }
+
+    public async Task<MeetOperationResult> JoinMeetAsync(int meetId, int userId)
+    {
+        _logger.LogInformation("User {UserId} attempting to join meet {MeetId}", userId, meetId);
+        var meet = await _context.Meets.Include(m => m.Users).FirstOrDefaultAsync(m => m.Id == meetId);
+        if (meet == null)
+        {
+            _logger.LogWarning("Meet not found with ID: {MeetId}", meetId);
+            return new MeetOperationResult { Success = false, ErrorMessage = "Meet not found" };
+        }
+
+        var user = await _context.Users.FindAsync(userId);
+        if (user == null)
+        {
+            _logger.LogWarning("User not found with ID: {UserId}", userId);
+            return new MeetOperationResult { Success = false, ErrorMessage = "User not found" };
+        }
+
+        if (meet.Users.Any(u => u.Id == userId))
+        {
+            _logger.LogWarning("User {UserId} already in meet {MeetId}", userId, meetId);
+            return new MeetOperationResult { Success = false, ErrorMessage = "User already joined the meet" };
+        }
+
+        meet.Users.Add(user);
+        await _context.SaveChangesAsync();
+        _logger.LogInformation("User {UserId} successfully joined meet {MeetId}", userId, meetId);
+
+        return new MeetOperationResult { Success = true };
+    }
+
+    public async Task<AllMeetsOperationResult> GetAllMeetsAsync()
+    {
+        _logger.LogInformation("Retrieving all meets");
+        var meets = await _context.Meets.Select(meet => new SmallEventResponse(meet)).ToListAsync();
+        return new AllMeetsOperationResult { Success = true, Meets = meets };
+    }
+
+    public async Task<AllMeetsOperationResult> GetFilteredMeetsAsync(LocationQuery query)
+    {
+        _logger.LogInformation("Retrieving filtered meets with query: {@Query}", query);
+        var meets = await _context.Meets.ToListAsync();
+
+        var filteredMeets = meets
+            .Where(m =>
+                CalculateDistance(m.Latitude, m.Longitude, query.Latitude, query.Longitude) <= query.DistanceInKm &&
+                (query.Tags.Count == 0 || m.Tags.Any(t => query.Tags.Contains(t.ToString()))) &&
+                m.Date >= DateTime.Today
+            )
+            .Select(meet => new SmallEventResponse(meet))
+            .ToList();
+
+        return new AllMeetsOperationResult { Success = true, Meets = filteredMeets };
+    }
+
+    private double CalculateDistance(double lat1, double lon1, double lat2, double lon2)
+    {
+        const double R = 6371; // Earth's radius in kilometers
+        var dLat = ToRadians(lat2 - lat1);
+        var dLon = ToRadians(lon2 - lon1);
+        var a = Math.Sin(dLat / 2) * Math.Sin(dLat / 2) +
+                Math.Cos(ToRadians(lat1)) * Math.Cos(ToRadians(lat2)) *
+                Math.Sin(dLon / 2) * Math.Sin(dLon / 2);
+        var c = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+        return R * c;
+    }
+
+    private double ToRadians(double degrees)
+    {
+        return degrees * Math.PI / 180;
+    }
+
+}

--- a/ThesisBackend/ThesisBackend.Services/MeetService/Validators/MeetRequestValidator.cs
+++ b/ThesisBackend/ThesisBackend.Services/MeetService/Validators/MeetRequestValidator.cs
@@ -22,7 +22,7 @@ public class MeetRequestValidator : AbstractValidator<MeetRequest>
 
         RuleFor(x => x.Date)
             .NotEmpty().WithMessage("Date is required.")
-            .GreaterThan(DateTime.Now).WithMessage("Date must be in the future.");
+            .GreaterThan(DateTime.UtcNow).WithMessage("Date must be in the future.");
 
         RuleFor(x => x.Tags)
             .NotEmpty().WithMessage("At least one tag is required.");

--- a/ThesisBackend/ThesisBackend.Services/MeetService/Validators/MeetRequestValidator.cs
+++ b/ThesisBackend/ThesisBackend.Services/MeetService/Validators/MeetRequestValidator.cs
@@ -1,0 +1,30 @@
+﻿using FluentValidation;
+using ThesisBackend.Domain.Messages;
+
+namespace ThesisBackend.Services.MeetService.Validators;
+
+public class MeetRequestValidator : AbstractValidator<MeetRequest>
+{
+    public MeetRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Name is required.")
+            .MaximumLength(64).WithMessage("Name must not exceed 64 characters.");
+
+        RuleFor(x => x.Location)
+            .NotEmpty().WithMessage("Location is required.")
+            .MaximumLength(128).WithMessage("Location must not exceed 128 characters.");
+
+        RuleFor(x => x.Coordinates)
+            .NotEmpty().WithMessage("Coordinates are required.")
+            .Matches(@"^-?\d+(\.\d+)?,-?\d+(\.\d+)?$")
+            .WithMessage("Invalid coordinate format. Expected format: 'latitude,longitude'.");
+
+        RuleFor(x => x.Date)
+            .NotEmpty().WithMessage("Date is required.")
+            .GreaterThan(DateTime.Now).WithMessage("Date must be in the future.");
+
+        RuleFor(x => x.Tags)
+            .NotEmpty().WithMessage("At least one tag is required.");
+    }
+}


### PR DESCRIPTION
This pull request refactors the `MeetController` to use a new `IMeetService` abstraction, introduces validation and logging, and adds comprehensive unit and integration tests for meet-related operations. The changes improve code maintainability, testability, and error handling, while also aligning meet management with a service-oriented architecture.

**Controller and Service Refactor:**
- The `MeetController` now delegates all business logic to an injected `IMeetService`, removing direct database access and in-method logic. FluentValidation is used for input validation, and structured logging is added for observability. Endpoints now return more consistent and informative responses.

**Dependency Injection and Validator Registration:**
- Registers `IMeetService` and its implementation, as well as `MeetRequestValidator`, in the dependency injection container and FluentValidation configuration. [[1]](diffhunk://#diff-c755a1e5a9d1acb8e87efdb321d89c6dee1e618fcb5922e61aae9e61137b59f6R23-R25) [[2]](diffhunk://#diff-c755a1e5a9d1acb8e87efdb321d89c6dee1e618fcb5922e61aae9e61137b59f6R92) [[3]](diffhunk://#diff-c755a1e5a9d1acb8e87efdb321d89c6dee1e618fcb5922e61aae9e61137b59f6R109)

**Testing Improvements:**
- Adds a new integration test class `MeetControllerTests` to verify API endpoints for adding, retrieving, and deleting meets using an in-memory database.
- Adds a unit test class `MeetServiceTest` for the service layer, covering add, get, delete, and join meet scenarios.

**Service and Result Abstractions:**
- Introduces the `IMeetService` interface and its result models (`MeetOperationResult`, `AllMeetsOperationResult`) to standardize responses from meet operations. [[1]](diffhunk://#diff-98e46a61a34f31893506f7cb7b6f60864ba7c51d829f2d007b41aa811e48d95cR1-R15) [[2]](diffhunk://#diff-83907e639c20e931870d896dcd627d42e1c517bf9acfff47a93083e589459ab0R1-R17)

**Minor Model Improvements:**
- Adds parameterless constructors to `MeetResponse` and `SmallEventResponse` to support serialization and testing. [[1]](diffhunk://#diff-90d3761fc81a6e9cabed172da0ae09fbbcfbd91eff67b22de588991edce5cb37R19-R20) [[2]](diffhunk://#diff-6e8b4c3f774fe1950271a1ba2a90ee3f9745181ba684d253dfd28ae467ed97dbR29-R32)